### PR TITLE
use repository pattern

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,57 +4,38 @@ import Title from "../components/Title";
 import Menu from "../components/Menu";
 import InventoryList from "../components/InventoryList";
 import InventoryDetail from "../components/InventoryDetail";
-
 import roomRepository from "../services/roomRepository";
-import tagRepository from "../services/tagRepository";
-import inventoryRepository from "../services/inventoryRepository";
-import { BASE_URL } from "../utils";
+// import tagRepository from "../services/tagRepository";
+// import inventoryRepository from "../services/inventoryRepository";
 
 import { useState, useCallback, useEffect } from "react";
 
 export default function Home() {
-  // mock response from API
   const [rooms, setRooms] = useState([]);
   const [tags, setTags] = useState([]);
   const [inventory, setInventory] = useState([]);
 
-  useEffect(() => {
-    const setAllRooms = async () => {
-      const rooms = await fetch(`${BASE_URL}/api/rooms`, {
-        method: "GET",
-      });
+  const setAllRooms = async () => {
+    const rooms = await roomRepository.all();
+    setRooms(await rooms.json());
+  };
 
-      setRooms(await rooms.json());
-    };
-
+  const addRoom = useCallback(async ({ name }) => {
+    await roomRepository.add(name);
     setAllRooms();
   }, []);
 
-  const addRoom = useCallback(async ({ name }) => {
-    await fetch(`${BASE_URL}/api/rooms/add`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name,
-      }),
-    });
-
-    const rooms = await fetch(`${BASE_URL}/api/rooms`, {
-      method: "GET",
-    });
-
-    setRooms(await rooms.json());
+  useEffect(() => {
+    setAllRooms();
   }, []);
 
-  tagRepository.all().then((response) => {
-    setTags(response.data);
-  });
+  // tagRepository.all().then((response) => {
+  //   setTags(response.data);
+  // });
 
-  inventoryRepository.all().then((response) => {
-    setInventory(response.data);
-  });
+  // inventoryRepository.all().then((response) => {
+  //   setInventory(response.data);
+  // });
 
   return (
     <div className="min-h-screen flex flex-col">

--- a/src/services/endpoints.js
+++ b/src/services/endpoints.js
@@ -1,13 +1,18 @@
+import { BASE_URL } from "../utils";
+
 const endpoints = {
   room: {
     all: {
-      method: 'get',
-      path: 'url_here',
+      method: 'GET',
+      path: `${BASE_URL}/api/rooms`,
     },
-    show: {
-      method: 'get',
-      path: 'url_here/:roomId',
-    },
+    add: {
+      method: 'POST',
+      path: `${BASE_URL}/api/rooms/add`,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
   },
   tag: {
     all: {

--- a/src/services/request.js
+++ b/src/services/request.js
@@ -1,10 +1,9 @@
-import axios from 'axios';
+export default function request({ method, headers, path }, params = {}) {
+  const { body } = params;
 
-export default function request({ method, path }, params = {}) {
-  let url = path;
-  const { search = {} } = params;
-  Object.keys(search).forEach((key) => {
-    url = url.replace(`:${key}`, search[key]);
+  return fetch(path, {
+    method,
+    headers,
+    body,
   });
-  return axios[method](url);
 }

--- a/src/services/roomRepository.js
+++ b/src/services/roomRepository.js
@@ -1,30 +1,12 @@
 import request from './request';
 import endpoints from './endpoints';
 
-// remove upon API implementation
-import { roomsMock } from './mocks';
-
-// remove upon API implementation
-function delay(time, value) {
-  return new Promise(function(resolve) { 
-      setTimeout(resolve.bind(null, value), time)
-  });
-}
-
 const methods = {
   all() {
-    // uncomment upon API implementation
-    // return request(endpoints.room.all);
-
-    // remove upon API implementation
-    return delay(1000, { data: roomsMock });
+    return request(endpoints.room.all);
   },
-  show(roomId) {
-    // uncomment upon API implementation
-    // return request(endpoints.room.show, { search: { roomId } });
-
-    // remove upon API implementation
-    return delay(1000, { data: roomsMock.filter((r) => r.id === roomId) });
+  add(name) {
+    return request(endpoints.room.add, { body: JSON.stringify({ name })});
   }
 };
 


### PR DESCRIPTION
Move api calls to repositories inside services folder.

By creating this abstraction layer, the react component no longer cares how to communicate with the api, it simply calls roomRepository.all() or roomRepository.add() and all the request is handled by the repository. 

The code of the react component is cleaner.